### PR TITLE
when generating the restart script, check if zeoserver, memcached and pound are enabled

### DIFF
--- a/buildout-configs/templates/restart-portal.tpl
+++ b/buildout-configs/templates/restart-portal.tpl
@@ -42,10 +42,18 @@ PID_ZEO=$( cat "$$PREFIX/var/zeoserver.pid" 2>/dev/null )
 PID_POUND=$( cat "$$PREFIX/parts/poundconfig/var/pound.pid" 2>/dev/null )
 PID_MEMCACHED=$( cat "$$PREFIX/var/memcached.pid.${parts.configuration['memcache-port']}" 2>/dev/null )
 
-
+{% if parts.zeoserver.recipe %}
 test -f $$PREFIX/bin/zeoserver || exit 5
+{% end %}
+
+{% if parts['memcached-ctl'].recipe %}
 test -f $$PREFIX/bin/memcached || exit 5
+{% end %}
+
+{% if parts.poundbuild.recipe %}
 test -f $$PREFIX/bin/poundctl || exit 5
+{% end %}
+
 for name in "$${INSTANCES[@]}"; do
     test -f $$PREFIX/bin/$$name || exit 5
 done


### PR DESCRIPTION
When installing ESD, we found that the instances at dog servers where not restarted.

The restart-portal script checks if bin/zeoserver bin/memcached and bin/poundctl exist regardles the buildout configuration, so that's the reason the instances not to be restarted.

In our setup, there are 6 additional servers with zope instances, but they don't have neither zeoserver or pound configuration, so there is no need to make thoses checks.

With these changes the restart-portal only includes pound, memcached and zeoserver when they are really included in the buildout.